### PR TITLE
修改DbContext和SelectTable的注入方式

### DIFF
--- a/APIJSON.NET/APIJSON.NET/Startup.cs
+++ b/APIJSON.NET/APIJSON.NET/Startup.cs
@@ -51,8 +51,8 @@
             {
                 c.SwaggerDoc("v1", new Info { Title = "APIJSON.NET", Version = "v1" });
             });
-            services.AddSingleton<DbContext>();
-            services.AddSingleton<SelectTable>();
+            services.AddTransient<DbContext>();
+            services.AddTransient<SelectTable>();
             services.AddSingleton<TokenAuthConfiguration>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<IIdentityService, IdentityService>();


### PR DESCRIPTION
在Startup中，DbContext和SelectTable都采用单例注入的方式，这样在并发状况下会产生问题。根据SqlSugar文档，单实例跨线程使用是错误用法，因此这里应改为AddTransient